### PR TITLE
Fix code scanning alert no. 21: Incomplete multi-character sanitization

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -32,7 +32,8 @@
     "remark-unwrap-images": "^3.0.1",
     "ts-node": "^10.8.0",
     "undici": "^5.28.4",
-    "unist-util-visit": "^4.1.0"
+    "unist-util-visit": "^4.1.0",
+    "sanitize-html": "^2.13.1"
   },
   "devDependencies": {
     "@babel/core": "^7.17.5",

--- a/docs/src/model/markdown.tsx
+++ b/docs/src/model/markdown.tsx
@@ -13,7 +13,7 @@ import remarkGfm from "remark-gfm";
 import remarkUnwrapImages from "remark-unwrap-images";
 import rehypePrism from "rehype-prism";
 import remarkPrism from "remark-prism";
-
+import sanitizeHtml from "sanitize-html";
 import { DOCS_PATH, REPO_URL, TEMP_PATH } from "../config";
 import { ITabsState } from "../global-tabs";
 
@@ -100,7 +100,10 @@ export const withInsertedCodeFromLinks = (content: string) => {
 };
 
 export const withoutComments = (content: string) => {
-  return content.replace(/<!--[\s\S]*?-->/gm, "");
+  return sanitizeHtml(content, {
+    allowedTags: sanitizeHtml.defaults.allowedTags.filter(tag => tag !== '!--'),
+    allowedAttributes: {}
+  });
 };
 
 export const replacePlaceholders = (content: string) => {


### PR DESCRIPTION
Fixes [https://github.com/Dargon789/hardhat/security/code-scanning/21](https://github.com/Dargon789/hardhat/security/code-scanning/21)

To fix the problem, we should replace the custom regular expression with a well-tested sanitization library. This will ensure that all edge cases are handled correctly and that the input is thoroughly sanitized. The `sanitize-html` library is a popular choice for this purpose.

1. Install the `sanitize-html` library.
2. Replace the custom regex-based sanitization with a call to `sanitize-html`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
