### PR TITLE
Potential fix for code scanning alert no. 8: Incomplete string escaping or encoding

### DIFF
--- a/packages/hardhat-truffle5/src/artifacts.ts
+++ b/packages/hardhat-truffle5/src/artifacts.ts
@@ -124,7 +124,7 @@ export class TruffleEnvironmentArtifacts {
           const libraryIdentifier = linkPlaceholder
             .slice(2)
             .replace(/_+$/, "")
-            .replace(/\\/g, "\\\\")
+            .replace(/[\\^$*+?.()|[\\\]{}]/g, "\\$&")
             .replace(/\$/g, "\\$");
 
           libraryAddresses[libraryIdentifier] = library.address;

--- a/packages/hardhat-truffle5/src/artifacts.ts
+++ b/packages/hardhat-truffle5/src/artifacts.ts
@@ -124,6 +124,7 @@ export class TruffleEnvironmentArtifacts {
           const libraryIdentifier = linkPlaceholder
             .slice(2)
             .replace(/_+$/, "")
+            .replace(/\\/g, "\\\\")
             .replace(/\$/g, "\\$");
 
           libraryAddresses[libraryIdentifier] = library.address;


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/hardhat/security/code-scanning/8](https://github.com/Dargon789/hardhat/security/code-scanning/8)

General fix: when doing manual escaping, escape backslashes first, then escape other metacharacters globally. This avoids producing partially escaped output and prevents backslash from neutralizing later escapes.

Best fix in this file/region: in `packages/hardhat-truffle5/src/artifacts.ts`, update the `libraryIdentifier` construction (around lines 124–127) to add a global backslash escape before the `$` escape. Keep the trailing-underscore removal as-is to preserve semantics.

Needed changes:
- No new imports.
- Replace the existing chained expression with:
  - `.replace(/\\/g, "\\\\")` first
  - then `.replace(/\$/g, "\\$")`


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
